### PR TITLE
Add per-tile launch status dots and JSON views for web deck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Magic Launcher will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.2] - Paper Trail - (DONE)
+
+### Launch Log
+- New `/log` endpoint on the web deck: the recent launch history (timestamp, shortcut, status transition) as a CGA-styled table, newest first, auto-refreshing every 5 seconds. Linked from the header on every deck page.
+- Same endpoint answers `Accept: application/json` with the raw event list (epoch + ISO time, shortcut path, status) - the start of a machine-readable convention for agents and scripts, alongside the existing JSON `/status`.
+- Log is the in-memory event buffer from 1.2.1 (last 200 transitions), so it costs nothing extra and vanishes on restart - `launcher.log` remains the permanent record.
+
 ## [1.2.1] - Green Means Go - (DONE)
 
 ### Launch Feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Magic Launcher will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.1] - Green Means Go - (DONE)
+
+### Launch Feedback
+- Web tiles now carry a status dot in the icon corner: yellow while the launch is still running, green when it exited cleanly, red when it exited nonzero or failed to spawn.
+- Each tile tracks its own latest launch, so two things running is just two yellow dots - no global precedence rules.
+- New `/status` endpoint reports per-tile state as JSON; the page polls it every 2 seconds (paused while the tab is hidden). Without JavaScript, dots still render on each page load.
+- `Launcher` guts revamp: new `launch_process()` returns the process handle instead of discarding it, which is what makes exit-code tracking possible. `launch()` keeps its bool contract, so the native app is unchanged but can adopt the same trick later.
+- Status transitions are kept in a capped in-memory event log - groundwork for the 1.2.2 `/log` endpoint.
+
 ## [1.2] - Obscurity not Security - PLANNING
 
 ### Every Screen's a Stream Deck (DONE)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Magic Launcher will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.3] - Just a Launcher - (DONE)
+
+### Agents Welcome, Tightly Bounded
+- The deck pages (`/` and `/folder/<id>`) now answer `Accept: application/json` with the tile list - id, name, type, latest launch status, and a broken flag. Combined with the existing JSON `/launch`, `/status` and `/log`, the whole surface is machine-readable without any HTML scraping.
+- Deliberately minimal: the JSON never exposes the paths or args behind tiles. An agent can see what's launchable and what happened - launched, running, finished, failed - and nothing else. More information is the job of the agent's other tools; Magic Launcher is just a launcher.
+- The security model is unchanged and is the point: an agent can only invoke entries you pre-defined in shortcuts.json, by id, over a LAN-scoped (or localhost-only) socket. 404s are JSON too when asked for JSON.
+
 ## [1.2.2] - Paper Trail - (DONE)
 
 ### Launch Log

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Each tile shows a status dot for its latest launch: yellow while it's still
 running, green once it exits cleanly, red if it exited with an error or never
 started. Note that a GUI app counts as "running" until you close it.
 
+The LOG link in the header (or `/log`) shows the recent launch history -
+timestamp, shortcut, and each status change. It's in-memory only (last 200
+events, cleared on restart); `launcher.log` keeps the permanent record.
+Scripts and agents can request `/log` and `/status` with an
+`Accept: application/json` header to get the data without the HTML.
+
 The web view is strictly read-only: all editing stays in the native app, and
 the browser can only launch shortcuts that already exist in `shortcuts.json` -
 it can never send a command of its own. There's no authentication, so only

--- a/README.md
+++ b/README.md
@@ -128,8 +128,14 @@ started. Note that a GUI app counts as "running" until you close it.
 The LOG link in the header (or `/log`) shows the recent launch history -
 timestamp, shortcut, and each status change. It's in-memory only (last 200
 events, cleared on restart); `launcher.log` keeps the permanent record.
-Scripts and agents can request `/log` and `/status` with an
-`Accept: application/json` header to get the data without the HTML.
+
+Scripts and agents can send `Accept: application/json` to any endpoint and
+get data instead of HTML: `/` and `/folder/<id>` list the tiles (id, name,
+type, latest status), `POST /launch` takes a tile id, and `/status` and
+`/log` report what happened. The JSON never exposes the commands behind
+tiles - an agent can only launch what you've pre-defined, by id, and see
+whether it launched, is running, finished or failed. Magic Launcher is just
+a launcher; anything more is the job of the agent's other tools.
 
 The web view is strictly read-only: all editing stays in the native app, and
 the browser can only launch shortcuts that already exist in `shortcuts.json` -

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Then open `http://<machine-ip>:8180/` on the device. Folders drill down like
 the native app, tapping a shortcut launches it on the server's machine, and
 edits made in native Magic Launcher show up on the next page load.
 
+Each tile shows a status dot for its latest launch: yellow while it's still
+running, green once it exits cleanly, red if it exited with an error or never
+started. Note that a GUI app counts as "running" until you close it.
+
 The web view is strictly read-only: all editing stays in the native app, and
 the browser can only launch shortcuts that already exist in `shortcuts.json` -
 it can never send a command of its own. There's no authentication, so only

--- a/launcher/constants.py
+++ b/launcher/constants.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 # Version
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 APP_NAME = "Shouldn't see this, use ConfigManager.get_app_name() instead"
 

--- a/launcher/constants.py
+++ b/launcher/constants.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 # Version
-VERSION = "1.2.2"
+VERSION = "1.3.0"
 
 APP_NAME = "Shouldn't see this, use ConfigManager.get_app_name() instead"
 

--- a/launcher/constants.py
+++ b/launcher/constants.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 # Version
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 
 APP_NAME = "Shouldn't see this, use ConfigManager.get_app_name() instead"
 

--- a/launcher/server.py
+++ b/launcher/server.py
@@ -18,6 +18,15 @@ Usage (same convention as app.py):
     python3 launcher/server.py --host 0.0.0.0 --port 8180   # expose to LAN
 
 No auth in v1 - network scope (localhost/LAN binding) is the boundary.
+
+Agent/script surface: every endpoint answers `Accept: application/json`
+with data instead of HTML. The launcher is just a launcher - it reports
+what can be launched and what happened, never the commands behind tiles:
+    GET  /                  tiles at the top level (id, name, type, status)
+    GET  /folder/<id>       tiles inside a folder
+    POST /launch  id=<id>   launch by trusted id -> {ok, status}
+    GET  /status            latest status per tile
+    GET  /log               recent launch events (in-memory, capped)
 """
 
 import argparse
@@ -369,6 +378,25 @@ def render_page(segments, items: dict, statuses: dict) -> str:
 </html>"""
 
 
+def items_json(segments, items: dict, statuses: dict) -> dict:
+    """The agent-facing view of one folder level: ids, names, types and
+    launch status only. Deliberately no paths or args - the launcher
+    reports what can be launched and what happened, nothing more."""
+    out = []
+    for name, item in items.items():
+        item_id = encode_id(segments + [name])
+        entry = {'id': item_id, 'name': name}
+        if isinstance(item, Folder):
+            entry['type'] = 'folder'
+        else:
+            entry['type'] = 'shortcut'
+            entry['status'] = statuses.get(item_id)
+            if not is_valid_target(item.path):
+                entry['broken'] = True
+        out.append(entry)
+    return {'path': segments, 'items': out}
+
+
 def render_log_page(events) -> str:
     """Render the launch event log, newest first, auto-refreshing."""
     rows = []
@@ -417,14 +445,27 @@ class StreamDeckHandler(BaseHTTPRequestHandler):
     def _send_html(self, code: int, text: str):
         self._send(code, 'text/html; charset=utf-8', text.encode('utf-8'))
 
+    def _wants_json(self) -> bool:
+        return 'application/json' in (self.headers.get('Accept') or '')
+
+    def _send_json(self, code: int, data):
+        self._send(code, 'application/json',
+                   json.dumps(data).encode('utf-8'))
+
     def _send_page(self, segments, items):
-        # Re-check target validity per page load so the red-X state
-        # tracks the filesystem, not the first request's cache.
+        # Re-check target validity per page load so the red-X/broken
+        # state tracks the filesystem, not the first request's cache.
         clear_validity_cache()
-        self._send_html(200, render_page(segments, items, tracker.statuses()))
+        if self._wants_json():
+            self._send_json(200, items_json(segments, items, tracker.statuses()))
+        else:
+            self._send_html(200, render_page(segments, items, tracker.statuses()))
 
     def _not_found(self):
-        self._send_html(404, '<h1>404</h1><p>Not found.</p>')
+        if self._wants_json():
+            self._send_json(404, {'error': 'not found'})
+        else:
+            self._send_html(404, '<h1>404</h1><p>Not found.</p>')
 
     def do_GET(self):
         path = urlparse(self.path).path

--- a/launcher/server.py
+++ b/launcher/server.py
@@ -23,6 +23,9 @@ No auth in v1 - network scope (localhost/LAN binding) is the boundary.
 import argparse
 import json
 import html
+import threading
+import time
+from collections import deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import quote, unquote, parse_qs, urlparse
@@ -91,6 +94,46 @@ def resolve(tree: dict, item_id: str):
             return None
         items = item.items if isinstance(item, Folder) else None
     return item
+
+
+# --- Launch tracking (the per-tile status dots) ---
+
+class LaunchTracker:
+    """Remembers each tile's latest launch so /status can report it.
+
+    Status per tile: 'running' while the process is alive, then 'ok'
+    (exit 0) or 'fail' (nonzero exit, or the launch never spawned).
+    Transitions are also appended to an in-memory event log, capped so
+    the server can't grow without bound.
+    """
+
+    def __init__(self, history: int = 200):
+        self._lock = threading.Lock()
+        self._latest = {}  # canonical item id -> launch record
+        self.events = deque(maxlen=history)  # (timestamp, id, status)
+
+    def start(self, item_id: str, proc) -> str:
+        status = 'running' if proc is not None else 'fail'
+        with self._lock:
+            self._latest[item_id] = {'proc': proc, 'status': status}
+            self.events.append((time.time(), item_id, status))
+        return status
+
+    def statuses(self) -> dict:
+        """Current status per tile, polling any still-running processes."""
+        with self._lock:
+            for item_id, rec in self._latest.items():
+                if rec['status'] != 'running':
+                    continue
+                code = rec['proc'].poll()
+                if code is not None:
+                    rec['status'] = 'ok' if code == 0 else 'fail'
+                    self.events.append((time.time(), item_id, rec['status']))
+            return {item_id: rec['status']
+                    for item_id, rec in self._latest.items()}
+
+
+tracker = LaunchTracker()
 
 
 # --- HTML rendering (the bbs_page.py move: config in, page out) ---
@@ -171,6 +214,18 @@ main {{
 }}
 .tile.ok .box {{ outline: 3px solid {COLORS['light_green']}; }}
 .tile.fail .box {{ outline: 3px solid {COLORS['light_red']}; }}
+.badge {{
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: 14px;
+    height: 14px;
+    border: 2px solid {COLORS['black']};
+    display: none;
+}}
+.badge.st-running {{ display: block; background: {COLORS['yellow']}; }}
+.badge.st-ok {{ display: block; background: {COLORS['light_green']}; }}
+.badge.st-fail {{ display: block; background: {COLORS['light_red']}; }}
 .empty {{ color: {COLORS['light_gray']}; padding: 20px; grid-column: 1 / -1; }}
 footer {{
     color: {COLORS['dark_gray']};
@@ -180,7 +235,10 @@ footer {{
 """
 
 # Tap a shortcut tile -> POST its id, flash the tile green/red.
-# Without JS the plain form submit still works (server 303s back).
+# Corner badges show each tile's latest launch state (yellow running,
+# green exited 0, red failed) and refresh from /status every 2s.
+# Without JS the plain form submit still works (server 303s back) and
+# badges are rendered server-side on each page load.
 PAGE_SCRIPT = """
 document.querySelectorAll('form.launch').forEach(function (form) {
     form.addEventListener('submit', function (ev) {
@@ -192,7 +250,10 @@ document.querySelectorAll('form.launch').forEach(function (form) {
                       'Accept': 'application/json'},
             body: 'id=' + encodeURIComponent(form.elements.id.value)
         }).then(function (r) { return r.json(); })
-          .then(function (data) { flash(tile, data.ok); })
+          .then(function (data) {
+              flash(tile, data.ok);
+              setBadge(tile, data.status);
+          })
           .catch(function () { flash(tile, false); });
     });
 });
@@ -200,6 +261,22 @@ function flash(tile, ok) {
     tile.classList.add(ok ? 'ok' : 'fail');
     setTimeout(function () { tile.classList.remove('ok', 'fail'); }, 500);
 }
+function setBadge(tile, status) {
+    var badge = tile.querySelector('.badge');
+    if (badge) badge.className = 'badge' + (status ? ' st-' + status : '');
+}
+function pollStatus() {
+    if (document.hidden) return;
+    fetch('/status', {headers: {'Accept': 'application/json'}})
+        .then(function (r) { return r.json(); })
+        .then(function (statuses) {
+            document.querySelectorAll('.tile.shortcut').forEach(function (tile) {
+                setBadge(tile, statuses[tile.dataset.id]);
+            });
+        })
+        .catch(function () {});
+}
+setInterval(pollStatus, 2000);
 """
 
 
@@ -213,7 +290,7 @@ def render_icon(item: BaseItem) -> str:
     return html.escape(text)
 
 
-def render_tile(item: BaseItem, segments) -> str:
+def render_tile(item: BaseItem, segments, statuses: dict) -> str:
     item_id = encode_id(segments)
     name = html.escape(item.name)
     if isinstance(item, Folder):
@@ -221,14 +298,18 @@ def render_tile(item: BaseItem, segments) -> str:
                 f'<span class="box">{render_icon(item)}</span>'
                 f'<span class="name">{name}</span></a>')
     broken = '' if is_valid_target(item.path) else ' broken'
+    status = statuses.get(item_id)
+    badge_class = f'badge st-{status}' if status else 'badge'
     return (f'<form class="launch" method="POST" action="/launch">'
             f'<input type="hidden" name="id" value="{html.escape(item_id)}">'
-            f'<button class="tile shortcut{broken}" type="submit">'
-            f'<span class="box">{render_icon(item)}</span>'
+            f'<button class="tile shortcut{broken}" type="submit" '
+            f'data-id="{html.escape(item_id)}">'
+            f'<span class="box">{render_icon(item)}'
+            f'<span class="{badge_class}"></span></span>'
             f'<span class="name">{name}</span></button></form>')
 
 
-def render_page(segments, items: dict) -> str:
+def render_page(segments, items: dict, statuses: dict) -> str:
     """Render one folder level (segments == [] for the top level)."""
     crumbs = ['<a href="/">HOME</a>']
     for i, seg in enumerate(segments):
@@ -236,7 +317,8 @@ def render_page(segments, items: dict) -> str:
                       f'{html.escape(seg)}</a>')
     breadcrumb = ' <span>&gt;</span> '.join(crumbs)
 
-    tiles = [render_tile(item, segments + [name]) for name, item in items.items()]
+    tiles = [render_tile(item, segments + [name], statuses)
+             for name, item in items.items()]
     grid = '\n'.join(tiles) if tiles else '<p class="empty">No shortcuts here.</p>'
 
     title = html.escape(get_app_name())
@@ -279,7 +361,7 @@ class StreamDeckHandler(BaseHTTPRequestHandler):
         # Re-check target validity per page load so the red-X state
         # tracks the filesystem, not the first request's cache.
         clear_validity_cache()
-        self._send_html(200, render_page(segments, items))
+        self._send_html(200, render_page(segments, items, tracker.statuses()))
 
     def _not_found(self):
         self._send_html(404, '<h1>404</h1><p>Not found.</p>')
@@ -289,6 +371,9 @@ class StreamDeckHandler(BaseHTTPRequestHandler):
 
         if path == '/':
             self._send_page([], load_tree())
+        elif path == '/status':
+            payload = json.dumps(tracker.statuses()).encode('utf-8')
+            self._send(200, 'application/json', payload)
         elif path.startswith('/folder/'):
             item_id = path[len('/folder/'):].rstrip('/')
             item = resolve(load_tree(), item_id)
@@ -337,13 +422,18 @@ class StreamDeckHandler(BaseHTTPRequestHandler):
             self._respond_launch(False, refused=True)
             return
 
-        ok = Launcher.launch(item.path, item.args)
-        self._respond_launch(ok)
+        # Canonical id (client encoding may differ) so the tracker key
+        # always matches the data-id the tiles are rendered with.
+        canonical_id = encode_id(unquote(seg) for seg in item_id.split('/'))
+        proc = Launcher.launch_process(item.path, item.args)
+        status = tracker.start(canonical_id, proc)
+        self._respond_launch(proc is not None, status=status)
 
-    def _respond_launch(self, ok: bool, refused: bool = False):
+    def _respond_launch(self, ok: bool, refused: bool = False,
+                        status: str = 'fail'):
         if 'application/json' in (self.headers.get('Accept') or ''):
             code = 404 if refused else 200
-            payload = json.dumps({'ok': ok}).encode('utf-8')
+            payload = json.dumps({'ok': ok, 'status': status}).encode('utf-8')
             self._send(code, 'application/json', payload)
         else:
             # No-JS form fallback: bounce back to the page the tap came from

--- a/launcher/server.py
+++ b/launcher/server.py
@@ -70,6 +70,11 @@ def load_tree() -> dict:
     return {name: item_from_dict(name, item_data) for name, item_data in data.items()}
 
 
+def decode_id(item_id: str) -> str:
+    """Turn an encoded tree-path id back into a readable path for display."""
+    return '/'.join(unquote(seg) for seg in item_id.split('/'))
+
+
 def encode_id(segments) -> str:
     """Encode a list of item names into a URL-safe tree-path id.
 
@@ -131,6 +136,12 @@ class LaunchTracker:
                     self.events.append((time.time(), item_id, rec['status']))
             return {item_id: rec['status']
                     for item_id, rec in self._latest.items()}
+
+    def log(self) -> list:
+        """Chronological copy of the event log (oldest first)."""
+        self.statuses()  # settle any just-finished processes first
+        with self._lock:
+            return list(self.events)
 
 
 tracker = LaunchTracker()
@@ -227,6 +238,23 @@ main {{
 .badge.st-ok {{ display: block; background: {COLORS['light_green']}; }}
 .badge.st-fail {{ display: block; background: {COLORS['light_red']}; }}
 .empty {{ color: {COLORS['light_gray']}; padding: 20px; grid-column: 1 / -1; }}
+header .loglink {{ margin-left: auto; }}
+table.log {{
+    border-collapse: collapse;
+    margin: 14px;
+    width: calc(100% - 28px);
+    font-size: 0.9em;
+}}
+.log th, .log td {{
+    border: 1px solid {COLORS['dark_gray']};
+    padding: 5px 10px;
+    text-align: left;
+}}
+.log th {{ background: {COLORS['dark_gray']}; color: {COLORS['yellow']}; }}
+.log td {{ color: {COLORS['light_gray']}; }}
+.log td.st-running {{ color: {COLORS['yellow']}; }}
+.log td.st-ok {{ color: {COLORS['light_green']}; }}
+.log td.st-fail {{ color: {COLORS['light_red']}; }}
 footer {{
     color: {COLORS['dark_gray']};
     font-size: 0.8em;
@@ -331,12 +359,44 @@ def render_page(segments, items: dict, statuses: dict) -> str:
 <style>{PAGE_STYLE}</style>
 </head>
 <body>
-<header><h1>{title}</h1><nav>{breadcrumb}</nav></header>
+<header><h1>{title}</h1><nav>{breadcrumb}</nav><nav class="loglink"><a href="/log">LOG</a></nav></header>
 <main>
 {grid}
 </main>
 <footer>Magic Launcher Server v{VERSION} - read-only view, edit in the native app</footer>
 <script>{PAGE_SCRIPT}</script>
+</body>
+</html>"""
+
+
+def render_log_page(events) -> str:
+    """Render the launch event log, newest first, auto-refreshing."""
+    rows = []
+    for ts, item_id, status in reversed(events):
+        stamp = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(ts))
+        rows.append(f'<tr><td>{stamp}</td>'
+                    f'<td>{html.escape(decode_id(item_id))}</td>'
+                    f'<td class="st-{status}">{status.upper()}</td></tr>')
+    if rows:
+        table = ('<table class="log"><tr><th>Time</th><th>Shortcut</th>'
+                 '<th>Status</th></tr>' + '\n'.join(rows) + '</table>')
+    else:
+        table = '<p class="empty">No launches yet.</p>'
+
+    title = html.escape(get_app_name())
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="5">
+<title>{title} - Log</title>
+<style>{PAGE_STYLE}</style>
+</head>
+<body>
+<header><h1>{title}</h1><nav><a href="/">HOME</a> <span>&gt;</span> LOG</nav></header>
+{table}
+<footer>Magic Launcher Server v{VERSION} - last {len(events)} launch events, in memory only</footer>
 </body>
 </html>"""
 
@@ -374,6 +434,20 @@ class StreamDeckHandler(BaseHTTPRequestHandler):
         elif path == '/status':
             payload = json.dumps(tracker.statuses()).encode('utf-8')
             self._send(200, 'application/json', payload)
+        elif path == '/log':
+            events = tracker.log()
+            if 'application/json' in (self.headers.get('Accept') or ''):
+                payload = json.dumps([
+                    {'time': ts,
+                     'iso': time.strftime('%Y-%m-%dT%H:%M:%S',
+                                          time.localtime(ts)),
+                     'id': item_id,
+                     'shortcut': decode_id(item_id),
+                     'status': status}
+                    for ts, item_id, status in events]).encode('utf-8')
+                self._send(200, 'application/json', payload)
+            else:
+                self._send_html(200, render_log_page(events))
         elif path.startswith('/folder/'):
             item_id = path[len('/folder/'):].rstrip('/')
             item = resolve(load_tree(), item_id)

--- a/launcher/utils/launcher.py
+++ b/launcher/utils/launcher.py
@@ -49,13 +49,25 @@ class Launcher:
     def launch(path: str, args: str = "") -> bool:
         """
         Launch a program, URL, or file.
-        
+
         Returns True if successful, False otherwise.
+        """
+        return Launcher.launch_process(path, args) is not None
+
+    @staticmethod
+    def launch_process(path: str, args: str = "") -> Optional[subprocess.Popen]:
+        """
+        Launch a program, URL, or file and return its process handle.
+
+        Returns the Popen object (poll() it to track running/succeeded/
+        failed), or None if the launch failed. For URLs and text files
+        the handle is the opener process (xdg-open etc.), which exits
+        as soon as it has handed the target off.
         """
         if not path:
             logger.warning("Attempted to launch empty path")
-            return False
-        
+            return None
+
         try:
             # Build full command
             if args:
@@ -87,40 +99,37 @@ class Launcher:
                 logger.info(f"Setting working directory to: {cwd}")
             
             # Execute as command
-            subprocess.Popen(cmd, shell=True, cwd=cwd)
-            return True
-            
+            return subprocess.Popen(cmd, shell=True, cwd=cwd)
+
         except Exception as e:
             logger.error(f"Launch error for '{path}': {e}")
-            return False
-    
+            return None
+
     @staticmethod
-    def _open_url(url: str) -> bool:
+    def _open_url(url: str) -> Optional[subprocess.Popen]:
         """Open a URL in the default browser."""
         try:
             if platform.system() == 'Darwin':
-                subprocess.Popen(['open', url])
+                return subprocess.Popen(['open', url])
             elif platform.system() == 'Windows':
-                subprocess.Popen(['start', url], shell=True)
+                return subprocess.Popen(['start', url], shell=True)
             else:
-                subprocess.Popen(['xdg-open', url])
-            return True
+                return subprocess.Popen(['xdg-open', url])
         except Exception as e:
             logger.error(f"Error opening URL '{url}': {e}")
-            return False
-    
+            return None
+
     @staticmethod
-    def _open_text_file(path: str) -> bool:
+    def _open_text_file(path: str) -> Optional[subprocess.Popen]:
         """Open a text file in the default editor."""
         try:
             if platform.system() == 'Windows':
-                subprocess.Popen(['notepad', path])
+                return subprocess.Popen(['notepad', path])
             else:
-                subprocess.Popen(['xdg-open', path])
-            return True
+                return subprocess.Popen(['xdg-open', path])
         except Exception as e:
             logger.error(f"Error opening text file '{path}': {e}")
-            return False
+            return None
     
     @staticmethod
     def validate_path(path: str) -> Optional[str]:


### PR DESCRIPTION
This pull request implements Magic Launcher 1.3, focusing on making the launcher web interface and API more machine-friendly and adding per-tile launch status tracking. The main improvements are: all deck and folder endpoints now support machine-readable JSON, each tile visually shows its latest launch status (running, succeeded, failed), and a new `/log` endpoint exposes recent launch events in both HTML and JSON. The security model remains unchanged—agents can only launch pre-defined shortcuts, and no sensitive command details are exposed.

**Machine-readable API and agent support:**
* All deck pages (`/` and `/folder/<id>`) now support `Accept: application/json`, returning a list of tiles with id, name, type, latest status, and a broken flag, but never exposing underlying commands or arguments. 404 errors are also returned as JSON when requested. (`launcher/server.py`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R139) [[3]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R448-R491)
* The `/status` and `/log` endpoints provide JSON output for agents/scripts, reporting per-tile state and recent launch events. (`launcher/server.py`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R139) [[3]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R448-R491)

**Per-tile launch tracking and UI feedback:**
* Each shortcut tile now displays a colored status badge: yellow while running, green if exited cleanly, red if failed. Statuses update live via polling `/status` every 2 seconds, and are rendered server-side for non-JS clients. (`launcher/server.py`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R139) [[3]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R113-R158) [[4]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R237-R266) [[5]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1L195-R316) [[6]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1L216-R358) [[7]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R381-R431)
* The backend tracks each tile's latest launch using a `LaunchTracker` class, which records status transitions and exposes them for UI and API. (`launcher/server.py`)

**Launch event log:**
* Adds a `/log` endpoint showing the recent launch history (timestamp, shortcut, status) as an auto-refreshing HTML table, and as JSON for agents. The log is in-memory only (last 200 events, cleared on restart). (`launcher/server.py`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R139) [[3]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R381-R431) [[4]](diffhunk://#diff-accc47e818c186bbcbf5f82a673986d45b9f4ef371e2e7b3b8ae4e75170752f1R448-R491)

**Launcher process handling:**
* Refactors launching so that `Launcher.launch_process()` returns the process handle, enabling exit-code tracking. The old `launch()` method now simply returns success/failure based on whether a process was started. (`launcher/utils/launcher.py`) [[1]](diffhunk://#diff-9fbf28a66212f7ffdce64ee5b1fadcb688840c640e4b29e7e8c67673c5760ce4R55-R69) [[2]](diffhunk://#diff-9fbf28a66212f7ffdce64ee5b1fadcb688840c640e4b29e7e8c67673c5760ce4L90-R132)
* All launch invocations in the server now use `launch_process()` and track status via the `LaunchTracker`. (`launcher/server.py`)

**Version bump:**
* Updates the version to 1.3.0 in `launcher/constants.py`.